### PR TITLE
refactor: Remove Uniswap library dependencies

### DIFF
--- a/scripts/Deployments.s.sol
+++ b/scripts/Deployments.s.sol
@@ -7,8 +7,6 @@ import "../src/LiquidityPoolFactory.sol";
 import "../src/LiquidityPool.sol";
 import "../src/PriceFeedL1.sol";
 import {UniswapV3Helper} from "../src/UniswapV3Helper.sol";
-import "@uniswapCore/contracts/UniswapV3Pool.sol";
-import {SwapRouter} from "@uniswapPeriphery/contracts/SwapRouter.sol";
 
 import "forge-std/Script.sol";
 import "forge-std/console.sol"; // Added for logging
@@ -24,7 +22,6 @@ contract Deployments is Script, HelperConfig {
     LiquidityPool public lbPoolWETH;
     LiquidityPool public lbPoolUSDC;
     LiquidityPool public lbPoolDAI; // Added for DAI
-    SwapRouter public swapRouter;
 
     address public alice;
     address public bob;
@@ -55,7 +52,6 @@ contract Deployments is Script, HelperConfig {
             address(priceFeedL1),
             address(liquidityPoolFactory),
             conf.liquidityPoolFactoryUniswapV3,
-            conf.nonfungiblePositionManager,
             address(uniswapV3Helper),
             conf.liquidationReward
         );

--- a/src/UniswapV3Helper.sol
+++ b/src/UniswapV3Helper.sol
@@ -1,40 +1,74 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.19;
 
-import "forge-std/Test.sol";
-
-import "@openzeppelin/contracts/utils/math/Math.sol";
+import "./interfaces/IUniswapV3.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 contract UniswapV3Helper {
+    IUniswapV3SwapRouter public immutable swapRouter;
 
     constructor(address _swapRouter) {
-        // _swapRouter is the address of the Uniswap V3 SwapRouter
+        swapRouter = IUniswapV3SwapRouter(_swapRouter);
     }
 
-    // ------ SWAP ------
-
-    /** @dev Swap Helper */
     function swapExactInputSingle(
-        address _token0,
-        address _token1,
+        address _tokenIn,
+        address _tokenOut,
         uint24 _fee,
         uint256 _amountIn
     ) public returns (uint256 amountOut) {
-        //Add the required approvals hare
-        //use the _swapRouter to execute the swapExactInputSingle swap
+        // Transfer the tokens from Positions.sol to this contract
+        SafeERC20.safeTransferFrom(IERC20(_tokenIn), msg.sender, address(this), _amountIn);
 
+        // Approve the router to spend the input token.
+        SafeERC20.forceApprove(IERC20(_tokenIn), address(swapRouter), _amountIn);
+
+        IUniswapV3SwapRouter.ExactInputSingleParams memory params = IUniswapV3SwapRouter
+            .ExactInputSingleParams({
+                tokenIn: _tokenIn,
+                tokenOut: _tokenOut,
+                fee: _fee,
+                recipient: msg.sender,
+                deadline: block.timestamp,
+                amountIn: _amountIn,
+                amountOutMinimum: 0,
+                sqrtPriceLimitX96: 0
+            });
+
+        amountOut = swapRouter.exactInputSingle(params);
     }
 
     function swapExactOutputSingle(
-        address _token0,
-        address _token1,
+        address _tokenIn,
+        address _tokenOut,
         uint24 _fee,
-        uint256 amountOut,
-        uint256 amountInMaximum
-    ) public returns (uint256 amountIn) 
-    {
-        //Add the required approvals hare
-        //use the _swapRouter to execute the swapExactOutputSingle swap
-    }
+        uint256 _amountOut,
+        uint256 _amountInMaximum
+    ) public returns (uint256 amountIn) {
+        // Transfer the tokens from Positions.sol to this contract
+        SafeERC20.safeTransferFrom(IERC20(_tokenIn), msg.sender, address(this), _amountInMaximum);
 
+        // Approve the router to spend the input token.
+        SafeERC20.forceApprove(IERC20(_tokenIn), address(swapRouter), _amountInMaximum);
+
+        IUniswapV3SwapRouter.ExactOutputSingleParams memory params = IUniswapV3SwapRouter
+            .ExactOutputSingleParams({
+                tokenIn: _tokenIn,
+                tokenOut: _tokenOut,
+                fee: _fee,
+                recipient: msg.sender,
+                deadline: block.timestamp,
+                amountOut: _amountOut,
+                amountInMaximum: _amountInMaximum,
+                sqrtPriceLimitX96: 0
+            });
+
+        amountIn = swapRouter.exactOutputSingle(params);
+
+        // Refund the unused tokens
+        if (amountIn < _amountInMaximum) {
+            SafeERC20.safeTransfer(IERC20(_tokenIn), msg.sender, _amountInMaximum - amountIn);
+        }
+    }
 }

--- a/src/interfaces/IMarket.sol
+++ b/src/interfaces/IMarket.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
-import "@uniswapCore/contracts/UniswapV3Pool.sol";
-
 /*
  * @title IMarket interface
  * @notice Interface for the Market contract

--- a/src/interfaces/IUniswapV3.sol
+++ b/src/interfaces/IUniswapV3.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+interface IUniswapV3SwapRouter {
+    struct ExactInputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 deadline;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    function exactInputSingle(ExactInputSingleParams calldata params) external payable returns (uint256 amountOut);
+
+    struct ExactOutputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 deadline;
+        uint256 amountOut;
+        uint256 amountInMaximum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    function exactOutputSingle(ExactOutputSingleParams calldata params) external payable returns (uint256 amountIn);
+}
+
+interface IUniswapV3Factory {
+    function getPool(address tokenA, address tokenB, uint24 fee) external view returns (address pool);
+}
+
+interface IUniswapV3Pool {
+    function fee() external view returns (uint24);
+    function token0() external view returns (address);
+    function token1() external view returns (address);
+    function factory() external view returns (address);
+}

--- a/test/utils/TestSetup.sol
+++ b/test/utils/TestSetup.sol
@@ -10,8 +10,6 @@ import {UniswapV3Helper} from "../../src/UniswapV3Helper.sol";
 import "../mocks/MockV3Aggregator.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import "@uniswapCore/contracts/UniswapV3Pool.sol";
-
 import "forge-std/Test.sol";
 import "../utils/HelperConfig.sol";
 import {Utils} from "./Utils.sol";
@@ -64,7 +62,6 @@ contract TestSetup is Test, HelperConfig, Utils {
             address(priceFeedL1),
             address(liquidityPoolFactory),
             conf.liquidityPoolFactoryUniswapV3,
-            conf.nonfungiblePositionManager,
             address(uniswapV3Helper),
             conf.liquidationReward
         );

--- a/test/utils/Utils.sol
+++ b/test/utils/Utils.sol
@@ -4,20 +4,12 @@ pragma solidity ^0.8.0;
 import "forge-std/Test.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@uniswapCore/contracts/UniswapV3Factory.sol";
 import "../mocks/MockV3Aggregator.sol";
 import "../../src/PriceFeedL1.sol";
 import "../../src/UniswapV3Helper.sol";
 
 contract Utils is Test {
     using stdStorage for StdStorage;
-
-    UniswapV3Factory factory = UniswapV3Factory(0x1F98431c8aD98523631AE4a59f267346ea31F984);
-
-    function getPool(address tokenA, address tokenB, uint24 fee) public view returns (address) {
-        address out = factory.getPool(tokenA, tokenB, fee);
-        return out;
-    }
 
     function writeTokenBalance(address who, address token, uint256 amt) public {
         stdstore.target(token).sig(IERC20(token).balanceOf.selector).with_key(who).checked_write(


### PR DESCRIPTION
Refactor UniswapV3Helper to perform swaps using interfaces instead of Uniswap libraries. The UniswapV3Helper constructor now only takes the SWAP_ROUTER_ADDRESS. Remove liquidity provision logic (mintPosition, etc.) from UniswapV3Helper and Positions. Create a new IUniswapV3.sol interface file.
Update Positions.sol to use the new interfaces and remove dependencies on Uniswap libraries. Update the deployment script to reflect the changes in the Positions constructor. The code compiles successfully.