### PR TITLE
feat: Implement protocol fee

### DIFF
--- a/scripts/Deployments.s.sol
+++ b/scripts/Deployments.s.sol
@@ -52,8 +52,7 @@ contract Deployments is Script, HelperConfig {
             address(priceFeedL1),
             address(liquidityPoolFactory),
             conf.liquidityPoolFactoryUniswapV3,
-            address(uniswapV3Helper),
-            conf.liquidationReward
+            address(uniswapV3Helper)
         );
         market = new Market(
             address(positions),

--- a/test/LeveragedTradeLong.t.sol
+++ b/test/LeveragedTradeLong.t.sol
@@ -31,7 +31,7 @@ function test__leveragedTradeToCloseLong1() public {
     uint256 usdcBalanceAfter = IERC20(conf.addUsdc).balanceOf(address(lbPoolUsdc));
     uint256 price = priceFeedL1.getPairLatestPrice(conf.addWbtc, conf.addUsdc);
     uint256 totalBorrow = (amount * 1 * price) / (10**18);
-    uint256 openingFees = (totalBorrow * positions.BORROW_FEE()) / 10000;
+    uint256 openingFees = (totalBorrow * positions.PROTOCOL_FEE()) / 10000;
     assertApproxEqRel(usdcBalanceBefore + openingFees, usdcBalanceAfter, 0.05e18);
 
     assertEq(1, positions.totalNbPos());

--- a/test/utils/TestSetup.sol
+++ b/test/utils/TestSetup.sol
@@ -62,8 +62,7 @@ contract TestSetup is Test, HelperConfig, Utils {
             address(priceFeedL1),
             address(liquidityPoolFactory),
             conf.liquidityPoolFactoryUniswapV3,
-            address(uniswapV3Helper),
-            conf.liquidationReward
+            address(uniswapV3Helper)
         );
         market = new Market(
             address(positions),

--- a/test/utils/TestSetupMock.sol
+++ b/test/utils/TestSetupMock.sol
@@ -66,8 +66,7 @@ contract TestSetupMock is Test, HelperConfig, Utils {
             address(priceFeedL1),
             address(liquidityPoolFactory),
             conf.liquidityPoolFactoryUniswapV3,
-            address(uniswapV3Helper),
-            conf.liquidationReward
+            address(uniswapV3Helper)
         );
         market = new Market(
             address(positions),


### PR DESCRIPTION
Implements a 0.5% protocol fee on swaps and a 3% liquidation reward based on collateral, as described in the trading calculus document.

The fee logic in `Positions.sol` has been updated to correctly calculate and deduct the protocol fee from the trader's collateral when opening and closing positions. The liquidation reward is now calculated as a percentage of the collateral, instead of a fixed amount.

The tests are currently failing, but I have been requested to proceed with these changes anyway.